### PR TITLE
fixed lack of input rollback on partial matches

### DIFF
--- a/sequenceof2.go
+++ b/sequenceof2.go
@@ -6,12 +6,14 @@ type sequenceOf2Parser[A, B any] struct {
 }
 
 func (p sequenceOf2Parser[A, B]) Parse(in *Input) (match Tuple2[A, B], ok bool, err error) {
+	start := in.Index()
 	match.A, ok, err = p.A.Parse(in)
 	if err != nil || !ok {
 		return
 	}
 	match.B, ok, err = p.B.Parse(in)
 	if err != nil || !ok {
+		in.Seek(start)
 		return
 	}
 	return

--- a/sequenceof3.go
+++ b/sequenceof3.go
@@ -7,16 +7,20 @@ type sequenceOf3Parser[A, B, C any] struct {
 }
 
 func (p sequenceOf3Parser[A, B, C]) Parse(in *Input) (match Tuple3[A, B, C], ok bool, err error) {
+	start := in.Index()
 	match.A, ok, err = p.A.Parse(in)
 	if err != nil || !ok {
+		in.Seek(start)
 		return
 	}
 	match.B, ok, err = p.B.Parse(in)
 	if err != nil || !ok {
+		in.Seek(start)
 		return
 	}
 	match.C, ok, err = p.C.Parse(in)
 	if err != nil || !ok {
+		in.Seek(start)
 		return
 	}
 	return

--- a/sequenceof4.go
+++ b/sequenceof4.go
@@ -8,20 +8,24 @@ type sequenceOf4Parser[A, B, C, D any] struct {
 }
 
 func (p sequenceOf4Parser[A, B, C, D]) Parse(in *Input) (match Tuple4[A, B, C, D], ok bool, err error) {
+	start := in.Index()
 	match.A, ok, err = p.A.Parse(in)
 	if err != nil || !ok {
 		return
 	}
 	match.B, ok, err = p.B.Parse(in)
 	if err != nil || !ok {
+		in.Seek(start)
 		return
 	}
 	match.C, ok, err = p.C.Parse(in)
 	if err != nil || !ok {
+		in.Seek(start)
 		return
 	}
 	match.D, ok, err = p.D.Parse(in)
 	if err != nil || !ok {
+		in.Seek(start)
 		return
 	}
 	return

--- a/sequenceof5.go
+++ b/sequenceof5.go
@@ -9,24 +9,29 @@ type sequenceOf5Parser[A, B, C, D, E any] struct {
 }
 
 func (p sequenceOf5Parser[A, B, C, D, E]) Parse(in *Input) (match Tuple5[A, B, C, D, E], ok bool, err error) {
+	start := in.Index()
 	match.A, ok, err = p.A.Parse(in)
 	if err != nil || !ok {
 		return
 	}
 	match.B, ok, err = p.B.Parse(in)
 	if err != nil || !ok {
+		in.Seek(start)
 		return
 	}
 	match.C, ok, err = p.C.Parse(in)
 	if err != nil || !ok {
+		in.Seek(start)
 		return
 	}
 	match.D, ok, err = p.D.Parse(in)
 	if err != nil || !ok {
+		in.Seek(start)
 		return
 	}
 	match.E, ok, err = p.E.Parse(in)
 	if err != nil || !ok {
+		in.Seek(start)
 		return
 	}
 	return

--- a/sequenceof6.go
+++ b/sequenceof6.go
@@ -10,28 +10,34 @@ type sequenceOf6Parser[A, B, C, D, E, F any] struct {
 }
 
 func (p sequenceOf6Parser[A, B, C, D, E, F]) Parse(in *Input) (match Tuple6[A, B, C, D, E, F], ok bool, err error) {
+	start := in.Index()
 	match.A, ok, err = p.A.Parse(in)
 	if err != nil || !ok {
 		return
 	}
 	match.B, ok, err = p.B.Parse(in)
 	if err != nil || !ok {
+		in.Seek(start)
 		return
 	}
 	match.C, ok, err = p.C.Parse(in)
 	if err != nil || !ok {
+		in.Seek(start)
 		return
 	}
 	match.D, ok, err = p.D.Parse(in)
 	if err != nil || !ok {
+		in.Seek(start)
 		return
 	}
 	match.E, ok, err = p.E.Parse(in)
 	if err != nil || !ok {
+		in.Seek(start)
 		return
 	}
 	match.F, ok, err = p.F.Parse(in)
 	if err != nil || !ok {
+		in.Seek(start)
 		return
 	}
 	return

--- a/sequenceof7.go
+++ b/sequenceof7.go
@@ -11,32 +11,39 @@ type sequenceOf7Parser[A, B, C, D, E, F, G any] struct {
 }
 
 func (p sequenceOf7Parser[A, B, C, D, E, F, G]) Parse(in *Input) (match Tuple7[A, B, C, D, E, F, G], ok bool, err error) {
+	start := in.Index()
 	match.A, ok, err = p.A.Parse(in)
 	if err != nil || !ok {
 		return
 	}
 	match.B, ok, err = p.B.Parse(in)
 	if err != nil || !ok {
+		in.Seek(start)
 		return
 	}
 	match.C, ok, err = p.C.Parse(in)
 	if err != nil || !ok {
+		in.Seek(start)
 		return
 	}
 	match.D, ok, err = p.D.Parse(in)
 	if err != nil || !ok {
+		in.Seek(start)
 		return
 	}
 	match.E, ok, err = p.E.Parse(in)
 	if err != nil || !ok {
+		in.Seek(start)
 		return
 	}
 	match.F, ok, err = p.F.Parse(in)
 	if err != nil || !ok {
+		in.Seek(start)
 		return
 	}
 	match.G, ok, err = p.G.Parse(in)
 	if err != nil || !ok {
+		in.Seek(start)
 		return
 	}
 	return

--- a/sequenceof8.go
+++ b/sequenceof8.go
@@ -12,36 +12,44 @@ type sequenceOf8Parser[A, B, C, D, E, F, G, H any] struct {
 }
 
 func (p sequenceOf8Parser[A, B, C, D, E, F, G, H]) Parse(in *Input) (match Tuple8[A, B, C, D, E, F, G, H], ok bool, err error) {
+	start := in.Index()
 	match.A, ok, err = p.A.Parse(in)
 	if err != nil || !ok {
 		return
 	}
 	match.B, ok, err = p.B.Parse(in)
 	if err != nil || !ok {
+		in.Seek(start)
 		return
 	}
 	match.C, ok, err = p.C.Parse(in)
 	if err != nil || !ok {
+		in.Seek(start)
 		return
 	}
 	match.D, ok, err = p.D.Parse(in)
 	if err != nil || !ok {
+		in.Seek(start)
 		return
 	}
 	match.E, ok, err = p.E.Parse(in)
 	if err != nil || !ok {
+		in.Seek(start)
 		return
 	}
 	match.F, ok, err = p.F.Parse(in)
 	if err != nil || !ok {
+		in.Seek(start)
 		return
 	}
 	match.G, ok, err = p.G.Parse(in)
 	if err != nil || !ok {
+		in.Seek(start)
 		return
 	}
 	match.H, ok, err = p.H.Parse(in)
 	if err != nil || !ok {
+		in.Seek(start)
 		return
 	}
 	return

--- a/sequenceof9.go
+++ b/sequenceof9.go
@@ -13,40 +13,49 @@ type sequenceOf9Parser[A, B, C, D, E, F, G, H, I any] struct {
 }
 
 func (p sequenceOf9Parser[A, B, C, D, E, F, G, H, I]) Parse(in *Input) (match Tuple9[A, B, C, D, E, F, G, H, I], ok bool, err error) {
+	start := in.Index()
 	match.A, ok, err = p.A.Parse(in)
 	if err != nil || !ok {
 		return
 	}
 	match.B, ok, err = p.B.Parse(in)
 	if err != nil || !ok {
+		in.Seek(start)
 		return
 	}
 	match.C, ok, err = p.C.Parse(in)
 	if err != nil || !ok {
+		in.Seek(start)
 		return
 	}
 	match.D, ok, err = p.D.Parse(in)
 	if err != nil || !ok {
+		in.Seek(start)
 		return
 	}
 	match.E, ok, err = p.E.Parse(in)
 	if err != nil || !ok {
+		in.Seek(start)
 		return
 	}
 	match.F, ok, err = p.F.Parse(in)
 	if err != nil || !ok {
+		in.Seek(start)
 		return
 	}
 	match.G, ok, err = p.G.Parse(in)
 	if err != nil || !ok {
+		in.Seek(start)
 		return
 	}
 	match.H, ok, err = p.H.Parse(in)
 	if err != nil || !ok {
+		in.Seek(start)
 		return
 	}
 	match.I, ok, err = p.I.Parse(in)
 	if err != nil || !ok {
+		in.Seek(start)
 		return
 	}
 	return

--- a/sequences_test.go
+++ b/sequences_test.go
@@ -15,6 +15,12 @@ func TestSequence2(t *testing.T) {
 			expectedOK: false,
 		},
 		{
+			name:       "partial match",
+			input:      "ABCDEF",
+			parser:     parse.SequenceOf2(parse.String("ABC"), parse.String("123")),
+			expectedOK: false,
+		},
+		{
 			name:   "match",
 			input:  "ABCDEF",
 			parser: parse.SequenceOf2(parse.String("ABC"), parse.String("DEF")),
@@ -34,6 +40,12 @@ func TestSequence3(t *testing.T) {
 			name:       "no match",
 			input:      "ABCDEF",
 			parser:     parse.SequenceOf3(parse.String("12"), parse.String("34"), parse.String("56")),
+			expectedOK: false,
+		},
+		{
+			name:       "partial match",
+			input:      "ABCDEF",
+			parser:     parse.SequenceOf3(parse.String("AB"), parse.String("CD"), parse.String("56")),
 			expectedOK: false,
 		},
 		{
@@ -60,6 +72,12 @@ func TestSequence4(t *testing.T) {
 			expectedOK: false,
 		},
 		{
+			name:       "partial match",
+			input:      "ABCDEFGHIJ",
+			parser:     parse.SequenceOf4(parse.String("A"), parse.String("B"), parse.String("3"), parse.String("4")),
+			expectedOK: false,
+		},
+		{
 			name:   "match",
 			input:  "ABCDEFGHIJ",
 			parser: parse.SequenceOf4(parse.String("A"), parse.String("B"), parse.String("C"), parse.String("D")),
@@ -81,6 +99,12 @@ func TestSequence5(t *testing.T) {
 			name:       "no match",
 			input:      "ABCDEFGHIJ",
 			parser:     parse.SequenceOf5(parse.String("1"), parse.String("2"), parse.String("3"), parse.String("4"), parse.String("5")),
+			expectedOK: false,
+		},
+		{
+			name:       "partial match",
+			input:      "ABCDEFGHIJ",
+			parser:     parse.SequenceOf5(parse.String("A"), parse.String("2"), parse.String("3"), parse.String("4"), parse.String("5")),
 			expectedOK: false,
 		},
 		{
@@ -109,6 +133,12 @@ func TestSequence6(t *testing.T) {
 			expectedOK: false,
 		},
 		{
+			name:       "partial match",
+			input:      "ABCDEFGHIJ",
+			parser:     parse.SequenceOf6(parse.String("A"), parse.String("B"), parse.String("C"), parse.String("4"), parse.String("5"), parse.String("6")),
+			expectedOK: false,
+		},
+		{
 			name:   "match",
 			input:  "ABCDEFGHIJ",
 			parser: parse.SequenceOf6(parse.String("A"), parse.String("B"), parse.String("C"), parse.String("D"), parse.String("E"), parse.String("F")),
@@ -132,6 +162,12 @@ func TestSequence7(t *testing.T) {
 			name:       "no match",
 			input:      "ABCDEFGHIJ",
 			parser:     parse.SequenceOf7(parse.String("1"), parse.String("2"), parse.String("3"), parse.String("4"), parse.String("5"), parse.String("6"), parse.String("7")),
+			expectedOK: false,
+		},
+		{
+			name:       "partial match",
+			input:      "ABCDEFGHIJ",
+			parser:     parse.SequenceOf7(parse.String("A"), parse.String("B"), parse.String("3"), parse.String("4"), parse.String("5"), parse.String("6"), parse.String("7")),
 			expectedOK: false,
 		},
 		{
@@ -162,6 +198,12 @@ func TestSequence8(t *testing.T) {
 			expectedOK: false,
 		},
 		{
+			name:       "partial match",
+			input:      "ABCDEFGHIJ",
+			parser:     parse.SequenceOf8(parse.String("A"), parse.String("B"), parse.String("3"), parse.String("4"), parse.String("5"), parse.String("6"), parse.String("7"), parse.String("8")),
+			expectedOK: false,
+		},
+		{
 			name:   "match",
 			input:  "ABCDEFGHIJ",
 			parser: parse.SequenceOf8(parse.String("A"), parse.String("B"), parse.String("C"), parse.String("D"), parse.String("E"), parse.String("F"), parse.String("G"), parse.String("H")),
@@ -187,6 +229,12 @@ func TestSequence9(t *testing.T) {
 			name:       "no match",
 			input:      "ABCDEFGHIJ",
 			parser:     parse.SequenceOf9(parse.String("1"), parse.String("2"), parse.String("3"), parse.String("4"), parse.String("5"), parse.String("6"), parse.String("7"), parse.String("8"), parse.String("9")),
+			expectedOK: false,
+		},
+		{
+			name:       "partial match",
+			input:      "ABCDEFGHIJ",
+			parser:     parse.SequenceOf9(parse.String("A"), parse.String("B"), parse.String("C"), parse.String("D"), parse.String("5"), parse.String("6"), parse.String("7"), parse.String("8"), parse.String("9")),
 			expectedOK: false,
 		},
 		{

--- a/stringuntil.go
+++ b/stringuntil.go
@@ -11,6 +11,7 @@ func (p stringUntilParser[T]) Parse(in *Input) (match string, ok bool, err error
 		beforeDelimiter := in.Index()
 		_, ok, err = p.Delimiter.Parse(in)
 		if err != nil {
+			in.Seek(start)
 			return
 		}
 		if ok {
@@ -22,6 +23,7 @@ func (p stringUntilParser[T]) Parse(in *Input) (match string, ok bool, err error
 			if p.AllowEOF {
 				break
 			}
+			in.Seek(start)
 			return "", false, nil
 		}
 	}

--- a/structure_test.go
+++ b/structure_test.go
@@ -39,7 +39,7 @@ func RunParserTests[T any](t *testing.T, tests []ParserTest[T]) {
 			}
 			if !test.expectedOK {
 				if in.Index() != 0 {
-					t.Error("Input not rolled back")
+					t.Error("input not rolled back")
 				}
 				return
 			}

--- a/structure_test.go
+++ b/structure_test.go
@@ -38,6 +38,9 @@ func RunParserTests[T any](t *testing.T, tests []ParserTest[T]) {
 				t.Errorf("expected ok=%v, got=%v", test.expectedOK, ok)
 			}
 			if !test.expectedOK {
+				if in.Index() != 0 {
+					t.Error("Input not rolled back")
+				}
 				return
 			}
 			if diff := cmp.Diff(test.expectedMatch, match); diff != "" {

--- a/until.go
+++ b/until.go
@@ -7,6 +7,7 @@ type untilParser[T, D any] struct {
 }
 
 func (p untilParser[T, D]) Parse(in *Input) (match []T, ok bool, err error) {
+	start := in.Index()
 	if _, ok = in.Peek(1); !ok && p.AllowEOF {
 		ok = true
 		return
@@ -24,6 +25,7 @@ func (p untilParser[T, D]) Parse(in *Input) (match []T, ok bool, err error) {
 		beforeDelimiter := in.Index()
 		_, ok, err = p.Delimiter.Parse(in)
 		if err != nil {
+			in.Seek(start)
 			return
 		}
 		if ok {
@@ -37,9 +39,11 @@ func (p untilParser[T, D]) Parse(in *Input) (match []T, ok bool, err error) {
 		var m T
 		m, ok, err = p.Parser.Parse(in)
 		if err != nil {
+			in.Seek(start)
 			return
 		}
 		if !ok {
+			in.Seek(start)
 			return
 		}
 		match = append(match, m)


### PR DESCRIPTION
My attempt at fixing issue #14. I updated `RunParserTests` to check for presence of input rollback on parsers that are expected to fail. This revealed similar problem in `Until` and `StringUntil` parsers, so I tried to fix them as well. Please have a look if the resolution makes sense